### PR TITLE
Enable pro projects with multi-file editor

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type {
 import type * as codeExecutions from "../codeExecutions.js";
 import type * as http from "../http.js";
 import type * as lemonSqueezy from "../lemonSqueezy.js";
+import type * as projects from "../projects.js";
 import type * as snippets from "../snippets.js";
 import type * as users from "../users.js";
 
@@ -31,9 +32,10 @@ declare const fullApi: ApiFromModules<{
   codeExecutions: typeof codeExecutions;
   http: typeof http;
   lemonSqueezy: typeof lemonSqueezy;
+  projects: typeof projects;
   snippets: typeof snippets;
   users: typeof users;
-}>;
+}>; 
 export declare const api: FilterApi<
   typeof fullApi,
   FunctionReference<any, "public">

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,0 +1,46 @@
+import { ConvexError } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const createProject = mutation({
+  args: {
+    name: v.string(),
+    language: v.string(),
+    files: v.array(v.object({ name: v.string(), content: v.string() })),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_user_id")
+      .filter((q) => q.eq(q.field("userId"), identity.subject))
+      .first();
+
+    if (!user) throw new Error("User not found");
+    if (!user.isPro) throw new ConvexError("Pro subscription required");
+
+    const id = await ctx.db.insert("projects", {
+      userId: identity.subject,
+      name: args.name,
+      language: args.language,
+      files: args.files,
+    });
+
+    return id;
+  },
+});
+
+export const getProjects = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+
+    return await ctx.db
+      .query("projects")
+      .withIndex("by_user_id")
+      .filter((q) => q.eq(q.field("userId"), identity.subject))
+      .collect();
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -42,4 +42,14 @@ export default defineSchema({
     .index("by_user_id", ["userId"])
     .index("by_snippet_id", ["snippetId"])
     .index("by_user_id_and_snippet_id", ["userId", "snippetId"]),
+
+    projects: defineTable({
+        userId: v.string(),
+        name: v.string(),
+        language: v.string(),
+        files: v.array(v.object({
+            name: v.string(),
+            content: v.string(),
+        })),
+    }).index("by_user_id", ["userId"]),
 });

--- a/src/app/(root)/_components/CreateProjectButton.tsx
+++ b/src/app/(root)/_components/CreateProjectButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { PlusCircle } from "lucide-react";
+
+function CreateProjectButton() {
+  const router = useRouter();
+  return (
+    <motion.button
+      onClick={() => router.push("/projects/new")}
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      className="group relative inline-flex items-center gap-2.5 px-5 py-2.5"
+    >
+      <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-blue-600 rounded-xl opacity-90 group-hover:opacity-100 transition-opacity" />
+      <div className="relative flex items-center gap-2.5">
+        <PlusCircle className="w-4 h-4 text-white/90" />
+        <span className="text-sm font-medium text-white/90 group-hover:text-white">New Project</span>
+      </div>
+    </motion.button>
+  );
+}
+
+export default CreateProjectButton;

--- a/src/app/(root)/_components/Header.tsx
+++ b/src/app/(root)/_components/Header.tsx
@@ -8,6 +8,7 @@ import ThemeSelector from "./ThemeSelector";
 import LanguageSelector from "./LanguageSelector";
 import RunButton from "./RunButton";
 import HeaderProfileBtn from "./HeaderProfileBtn";
+import CreateProjectButton from "./CreateProjectButton";
 
 
 async function Header() {
@@ -94,6 +95,7 @@ async function Header() {
           )}
 
           <SignedIn>
+            {convexUser?.isPro && <CreateProjectButton />}
             <RunButton />
           </SignedIn>
 

--- a/src/app/pricing/_constants/index.ts
+++ b/src/app/pricing/_constants/index.ts
@@ -29,6 +29,7 @@ export const FEATURES = {
     "Custom theme builder",
     "Integrated debugging tools",
     "Multi-language support",
+    "Create multi-file projects",
   ],
   collaboration: [
     "Real-time pair programming",

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import NavigationHeader from "@/components/NavigationHeader";
+import { Editor } from "@monaco-editor/react";
+import { useEffect, useState } from "react";
+import { defineMonacoThemes, LANGUAGE_CONFIG } from "@/app/(root)/_constants";
+import { useMutation } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { useRouter } from "next/navigation";
+
+function NewProjectPage() {
+  const [name, setName] = useState("");
+  const [language, setLanguage] = useState("javascript");
+  const [files, setFiles] = useState([{ name: `main.${language}`, content: "" }]);
+  const [active, setActive] = useState(0);
+  const createProject = useMutation(api.projects.createProject);
+  const router = useRouter();
+
+  useEffect(() => {
+    setFiles([{ name: `main.${language}`, content: "" }]);
+    setActive(0);
+  }, [language]);
+
+  const addFile = () => {
+    const idx = files.length + 1;
+    setFiles([...files, { name: `file${idx}.${language}`, content: "" }]);
+    setActive(files.length);
+  };
+
+  const updateFile = (value?: string) => {
+    setFiles(files.map((f, i) => (i === active ? { ...f, content: value || "" } : f)));
+  };
+
+  const save = async () => {
+    if (!name) return;
+    await createProject({ name, language, files });
+    router.push("/projects");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0f]">
+      <NavigationHeader />
+      <main className="max-w-5xl mx-auto p-4 space-y-4">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Project name"
+          className="w-full bg-[#1e1e2e] text-white p-2 rounded"
+        />
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          className="bg-[#1e1e2e] text-white p-2 rounded"
+        >
+          {Object.keys(LANGUAGE_CONFIG).map((lang) => (
+            <option key={lang} value={lang}>
+              {LANGUAGE_CONFIG[lang].label}
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-2 flex-wrap">
+          {files.map((file, i) => (
+            <button
+              key={i}
+              onClick={() => setActive(i)}
+              className={`px-3 py-1 rounded text-sm ${
+                i === active ? "bg-blue-600 text-white" : "bg-[#1e1e2e] text-gray-300"
+              }`}
+            >
+              {file.name}
+            </button>
+          ))}
+          <button onClick={addFile} className="px-3 py-1 rounded bg-[#1e1e2e] text-gray-300">
+            +
+          </button>
+        </div>
+        <Editor
+          key={files[active].name}
+          path={files[active].name}
+          language={LANGUAGE_CONFIG[language].monacoLanguage}
+          value={files[active].content}
+          onChange={updateFile}
+          theme="vs-dark"
+          beforeMount={defineMonacoThemes}
+          options={{ minimap: { enabled: false }, automaticLayout: true, fontSize: 16 }}
+        />
+        <button onClick={save} className="px-5 py-2 bg-blue-600 rounded text-white">
+          Save Project
+        </button>
+      </main>
+    </div>
+  );
+}
+export default NewProjectPage;

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import NavigationHeader from "@/components/NavigationHeader";
+
+function ProjectsPage() {
+  const projects = useQuery(api.projects.getProjects);
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0f]">
+      <NavigationHeader />
+      <main className="max-w-5xl mx-auto p-4 space-y-4">
+        <h1 className="text-2xl font-semibold text-white mb-4">Your Projects</h1>
+        <div className="space-y-2">
+          {projects?.map((p) => (
+            <div
+              key={p._id}
+              className="p-4 rounded-lg bg-[#1e1e2e] text-gray-300 flex justify-between"
+            >
+              <span>{p.name}</span>
+              <span className="text-sm text-gray-500">{p.language}</span>
+            </div>
+          ))}
+          {projects?.length === 0 && <p className="text-gray-400">No projects yet.</p>}
+        </div>
+      </main>
+    </div>
+  );
+}
+export default ProjectsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,3 +64,17 @@ export interface Snippet {
   title: string;
   userName: string;
 }
+
+export interface ProjectFile {
+  name: string;
+  content: string;
+}
+
+export interface Project {
+  _id: Id<"projects">;
+  _creationTime: number;
+  userId: string;
+  name: string;
+  language: string;
+  files: ProjectFile[];
+}


### PR DESCRIPTION
## Summary
- allow project creation from new Pro-only endpoint
- show a New Project button in the header
- add multi-file project editor and project listing
- update pricing page feature list
- extend Convex schema and generated API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68576968fe8083239e9bb87af15f6e8c