### PR TITLE
Add Pro project creation with multi-file editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **Access to premium languages** (Pro subscription required for non-JavaScript languages)
 - **Enhanced collaboration features**
 - **Priority support**
+- **Create multi-file projects**
 
 ### 🌐 **Modern UI/UX**
 - **Beautiful dark theme** with blue/purple gradients

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type {
 import type * as codeExecutions from "../codeExecutions.js";
 import type * as http from "../http.js";
 import type * as lemonSqueezy from "../lemonSqueezy.js";
+import type * as projects from "../projects.js";
 import type * as snippets from "../snippets.js";
 import type * as users from "../users.js";
 
@@ -31,6 +32,7 @@ declare const fullApi: ApiFromModules<{
   codeExecutions: typeof codeExecutions;
   http: typeof http;
   lemonSqueezy: typeof lemonSqueezy;
+  projects: typeof projects;
   snippets: typeof snippets;
   users: typeof users;
 }>;

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,0 +1,52 @@
+import { ConvexError } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const createProject = mutation({
+    args:{
+        title: v.string(),
+        language: v.string(),
+        files: v.array(v.object({ name: v.string(), content: v.string() })),
+    },
+    handler: async(ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new ConvexError("Not authenticated");
+
+        const user = await ctx.db
+            .query("users")
+            .withIndex("by_user_id")
+            .filter((q) => q.eq(q.field("userId"), identity.subject))
+            .first();
+
+        if (!user) throw new Error("User not found");
+        if (!user.isPro) throw new ConvexError("Pro subscription required");
+
+        const projectId = await ctx.db.insert("projects", {
+            userId: identity.subject,
+            title: args.title,
+            language: args.language,
+            files: args.files,
+            userName: user.name,
+        });
+
+        return projectId;
+    }
+});
+
+export const getUserProjects = query({
+    args: { userId: v.string() },
+    handler: async(ctx, args) => {
+        return await ctx.db
+            .query("projects")
+            .withIndex("by_user_id")
+            .filter((q) => q.eq(q.field("userId"), args.userId))
+            .collect();
+    }
+});
+
+export const getProjectById = query({
+    args: { projectId: v.id("projects") },
+    handler: async(ctx, args) => {
+        return await ctx.db.get(args.projectId);
+    }
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -28,6 +28,17 @@ export default defineSchema({
         userName: v.string(), // store user's name for easy access
     }).index("by_user_id", ["userId"]),
 
+    projects: defineTable({
+        userId: v.string(),
+        title: v.string(),
+        language: v.string(),
+        files: v.array(v.object({
+            name: v.string(),
+            content: v.string(),
+        })),
+        userName: v.string(),
+    }).index("by_user_id", ["userId"]),
+
     snippetComments: defineTable({
         snippetId: v.id("snippets"),
         userId: v.string(),

--- a/src/app/(root)/_components/Header.tsx
+++ b/src/app/(root)/_components/Header.tsx
@@ -55,11 +55,11 @@ async function Header() {
           <nav className="flex items-center space-x-1">
             <Link
               href="/snippets"
-              className="relative group flex items-center gap-2 px-4 py-1.5 rounded-lg text-gray-300 bg-gray-800/50 
+              className="relative group flex items-center gap-2 px-4 py-1.5 rounded-lg text-gray-300 bg-gray-800/50
                 hover:bg-blue-500/10 border border-gray-800 hover:border-blue-500/50 transition-all duration-300 shadow-lg overflow-hidden"
             >
               <div
-                className="absolute inset-0 bg-gradient-to-r from-blue-500/10 
+                className="absolute inset-0 bg-gradient-to-r from-blue-500/10
                 to-purple-500/10 opacity-0 group-hover:opacity-100 transition-opacity"
               />
               <Code2 className="w-4 h-4 relative z-10 group-hover:rotate-3 transition-transform" />
@@ -69,6 +69,14 @@ async function Header() {
               >
                 Snippets
               </span>
+            </Link>
+            <Link
+              href="/projects"
+              className="relative group flex items-center gap-2 px-4 py-1.5 rounded-lg text-gray-300 bg-gray-800/50 hover:bg-blue-500/10 border border-gray-800 hover:border-blue-500/50 transition-all duration-300 overflow-hidden"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 opacity-0 group-hover:opacity-100 transition-opacity" />
+              <Code2 className="w-4 h-4 relative z-10 group-hover:rotate-3 transition-transform" />
+              <span className="text-sm font-medium relative z-10 group-hover:text-white transition-colors">Projects</span>
             </Link>
           </nav>
         </div>
@@ -94,6 +102,14 @@ async function Header() {
           )}
 
           <SignedIn>
+            {convexUser?.isPro && (
+              <Link
+                href="/projects/new"
+                className="inline-flex items-center gap-2 px-4 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                New Project
+              </Link>
+            )}
             <RunButton />
           </SignedIn>
 

--- a/src/app/pricing/_constants/index.ts
+++ b/src/app/pricing/_constants/index.ts
@@ -29,6 +29,7 @@ export const FEATURES = {
     "Custom theme builder",
     "Integrated debugging tools",
     "Multi-language support",
+    "Create multi-file projects",
   ],
   collaboration: [
     "Real-time pair programming",

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { useEffect, useState } from "react";
+import NavigationHeader from "@/components/NavigationHeader";
+import { Editor } from "@monaco-editor/react";
+import { useProjectStore } from "@/store/useProjectStore";
+import { defineMonacoThemes, LANGUAGE_CONFIG } from "@/app/(root)/_constants";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+
+export default function NewProjectPage() {
+  const { user } = useUser();
+  const router = useRouter();
+  const convexUser = useQuery(api.users.getUser, { userId: user?.id ?? "" });
+  const createProject = useMutation(api.projects.createProject);
+  const {
+    files,
+    activeFileIndex,
+    addFile,
+    setActiveFile,
+    updateActiveFile,
+    setEditor,
+    language,
+    setLanguage,
+  } = useProjectStore();
+  const [title, setTitle] = useState("");
+
+  useEffect(() => {
+    if (convexUser && !convexUser.isPro) {
+      router.replace("/pricing");
+    }
+  }, [convexUser, router]);
+
+  if (convexUser === undefined) return null;
+
+  const handleSave = async () => {
+    await createProject({ title, language, files });
+    router.push("/projects");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0f]">
+      <NavigationHeader />
+      <div className="max-w-7xl mx-auto p-4 space-y-6">
+        <div className="flex flex-col gap-2">
+          <input
+            className="bg-[#1e1e2e] text-white px-3 py-2 rounded-lg border border-gray-800"
+            placeholder="Project Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-2 items-center">
+          <label className="text-gray-400 text-sm">Language:</label>
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="bg-[#1e1e2e] text-white px-2 py-1 rounded border border-gray-800"
+          >
+            {Object.keys(LANGUAGE_CONFIG).map((lang) => (
+              <option key={lang} value={lang}>
+                {LANGUAGE_CONFIG[lang].label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="bg-[#12121a]/90 border border-[#1f1f2a] rounded-xl">
+          <div className="flex items-center gap-2 p-2 border-b border-[#1f1f2a]">
+            {files.map((file, idx) => (
+              <button
+                key={idx}
+                onClick={() => setActiveFile(idx)}
+                className={`px-3 py-1.5 rounded text-sm ${activeFileIndex === idx ? "bg-blue-500/20 text-blue-300" : "text-gray-400 hover:text-gray-300"}`}
+              >
+                {file.name}
+              </button>
+            ))}
+            <button
+              onClick={() => addFile(`file${files.length + 1}.txt`)}
+              className="px-3 py-1.5 rounded text-sm text-gray-400 hover:text-gray-300"
+            >
+              + Add File
+            </button>
+          </div>
+          <Editor
+            height="600px"
+            language={LANGUAGE_CONFIG[language].monacoLanguage}
+            theme="vs-dark"
+            beforeMount={defineMonacoThemes}
+            onMount={(editor) => setEditor(editor)}
+            onChange={(val) => val && updateActiveFile(val)}
+          />
+        </div>
+        <button
+          onClick={handleSave}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+        >
+          Save Project
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { useUser } from "@clerk/nextjs";
+import NavigationHeader from "@/components/NavigationHeader";
+import Link from "next/link";
+
+export default function ProjectsPage() {
+  const { user } = useUser();
+  const projects = useQuery(api.projects.getUserProjects, { userId: user?.id ?? "" });
+
+  if (projects === undefined) return null;
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0f]">
+      <NavigationHeader />
+      <div className="max-w-7xl mx-auto p-4 space-y-4">
+        <h1 className="text-2xl text-white mb-4">Your Projects</h1>
+        <div className="space-y-3">
+          {projects.map((p) => (
+            <Link
+              key={p._id}
+              href="#"
+              className="block px-4 py-2 rounded-lg bg-[#1e1e2e] text-gray-300"
+            >
+              {p.title}
+            </Link>
+          ))}
+          {projects.length === 0 && (
+            <p className="text-gray-400">No projects yet.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { Monaco } from "@monaco-editor/react";
+import { ProjectFile } from "@/types";
+
+interface ProjectEditorState {
+  language: string;
+  files: ProjectFile[];
+  activeFileIndex: number;
+  editor: Monaco | null;
+  setEditor: (editor: Monaco) => void;
+  setLanguage: (lang: string) => void;
+  addFile: (name: string) => void;
+  setActiveFile: (index: number) => void;
+  updateActiveFile: (content: string) => void;
+  getFiles: () => ProjectFile[];
+}
+
+const getInitialFiles = (): ProjectFile[] => {
+  if (typeof window === "undefined") return [{ name: "main", content: "" }];
+  const stored = localStorage.getItem("project-files");
+  if (stored) return JSON.parse(stored);
+  return [{ name: "main", content: "" }];
+};
+
+export const useProjectStore = create<ProjectEditorState>((set, get) => ({
+  language: "javascript",
+  files: getInitialFiles(),
+  activeFileIndex: 0,
+  editor: null,
+  setEditor: (editor: Monaco) => {
+    const files = get().files;
+    editor.setValue(files[get().activeFileIndex]?.content || "");
+    set({ editor });
+  },
+  setLanguage: (lang: string) => set({ language: lang }),
+  addFile: (name: string) => {
+    const files = [...get().files, { name, content: "" }];
+    set({ files, activeFileIndex: files.length - 1 });
+    if (typeof window !== "undefined") {
+      localStorage.setItem("project-files", JSON.stringify(files));
+    }
+  },
+  setActiveFile: (index: number) => {
+    const editor = get().editor;
+    const files = get().files;
+    if (editor) editor.setValue(files[index]?.content || "");
+    set({ activeFileIndex: index });
+  },
+  updateActiveFile: (content: string) => {
+    const files = [...get().files];
+    files[get().activeFileIndex] = {
+      ...files[get().activeFileIndex],
+      content,
+    };
+    if (typeof window !== "undefined") {
+      localStorage.setItem("project-files", JSON.stringify(files));
+    }
+    set({ files });
+  },
+  getFiles: () => get().files,
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,3 +64,18 @@ export interface Snippet {
   title: string;
   userName: string;
 }
+
+export interface ProjectFile {
+  name: string;
+  content: string;
+}
+
+export interface Project {
+  _id: Id<"projects">;
+  _creationTime: number;
+  userId: string;
+  language: string;
+  title: string;
+  files: ProjectFile[];
+  userName: string;
+}


### PR DESCRIPTION
## Summary
- allow Pro users to create multi–file projects
- store projects in a new Convex table
- add project editing store and pages
- show Projects link and new project button in the header
- update pricing info and README

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68576968fe8083239e9bb87af15f6e8c