### PR TITLE
Add multi-file support to Monaco editor

### DIFF
--- a/src/app/(root)/_constants/index.ts
+++ b/src/app/(root)/_constants/index.ts
@@ -1,6 +1,19 @@
 import { Monaco } from "@monaco-editor/react";
 import { Theme } from "../../../types";
 
+export const LANGUAGE_EXTENSIONS: Record<string, string> = {
+  javascript: "js",
+  typescript: "ts",
+  python: "py",
+  java: "java",
+  go: "go",
+  rust: "rs",
+  cpp: "cpp",
+  csharp: "cs",
+  ruby: "rb",
+  swift: "swift",
+};
+
 type LanguageConfig = Record<
   string,
   {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,11 @@ export interface ExecutionResult {
   error: string | null;
 }
 
+export interface EditorFile {
+  name: string;
+  content: string;
+}
+
 export interface CodeEditorState {
   language: string;
   output: string;
@@ -47,8 +52,15 @@ export interface CodeEditorState {
   editor: Monaco | null;
   executionResult: ExecutionResult | null;
 
+  files: EditorFile[];
+  currentFileIndex: number;
+
   setEditor: (editor: Monaco) => void;
   getCode: () => string;
+  setCurrentFileIndex: (index: number) => void;
+  addFile: (name?: string) => void;
+  removeFile: (index: number) => void;
+  updateCurrentFileContent: (content: string) => void;
   setLanguage: (language: string) => void;
   setTheme: (theme: string) => void;
   setFontSize: (fontSize: number) => void;


### PR DESCRIPTION
## Summary
- add `EditorFile` type and extend `CodeEditorState` for multiple files
- provide file extension mapping in editor constants
- implement multi-file logic in store with add/remove/switch file actions
- update editor panel UI with tabs for files

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68576f3c88f88323912f43cebee350db