### PR TITLE
Add sandbox terminal tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-hot-toast": "^2.5.2",
         "react-syntax-highlighter": "^15.6.1",
         "svix": "^1.67.0",
+        "xterm": "^5.3.0",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -7684,6 +7685,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "react-hot-toast": "^2.5.2",
     "react-syntax-highlighter": "^15.6.1",
+    "xterm": "^5.3.0",
     "svix": "^1.67.0",
     "zustand": "^5.0.5"
   },

--- a/src/app/(root)/_components/OutputPanel.tsx
+++ b/src/app/(root)/_components/OutputPanel.tsx
@@ -3,10 +3,12 @@ import { useCodeEditorStore } from "@/store/useCodeEditorStore";
 import { AlertTriangle, CheckCircle, Clock, Copy, Terminal } from "lucide-react";
 import { useState } from "react";
 import RunningCodeSkeleton from "./RunningCodeSkeleton";
+import TerminalPanel from "./TerminalPanel";
 
 function OutputPanel() {
   const { output, error, isRunning } = useCodeEditorStore();
   const [isCopied, setIsCopied] = useState(false);
+  const [tab, setTab] = useState<"output" | "terminal">("output");
 
   const hasContent = true;
 
@@ -32,7 +34,7 @@ function OutputPanel() {
         {hasContent && (
           <button
             onClick={handleCopy}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-gray-400 hover:text-gray-300 bg-[#1e1e2e] 
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-gray-400 hover:text-gray-300 bg-[#1e1e2e]
             rounded-lg ring-1 ring-gray-800/50 hover:ring-gray-700/50 transition-all"
           >
             {isCopied ? (
@@ -50,39 +52,59 @@ function OutputPanel() {
         )}
       </div>
 
+      {/* Tabs */}
+      <div className="flex gap-2 mb-3">
+        <button
+          onClick={() => setTab("output")}
+          className={`px-3 py-1 rounded-md text-sm ${tab === "output" ? "bg-[#1e1e2e] text-white" : "bg-[#1e1e2e]/50 text-gray-400"}`}
+        >
+          Output
+        </button>
+        <button
+          onClick={() => setTab("terminal")}
+          className={`px-3 py-1 rounded-md text-sm ${tab === "terminal" ? "bg-[#1e1e2e] text-white" : "bg-[#1e1e2e]/50 text-gray-400"}`}
+        >
+          Terminal
+        </button>
+      </div>
+
       {/* Output Area */}
       <div className="relative">
-        <div
-          className="relative bg-[#1e1e2e]/50 backdrop-blur-sm border border-[#313244] 
+        {tab === "terminal" ? (
+          <TerminalPanel />
+        ) : (
+          <div
+            className="relative bg-[#1e1e2e]/50 backdrop-blur-sm border border-[#313244]
         rounded-xl p-4 h-[600px] overflow-auto font-mono text-sm"
-        >
-          {isRunning ? (
-            <RunningCodeSkeleton />
-          ) : error ? (
-            <div className="flex items-start gap-3 text-red-400">
-              <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-1" />
-              <div className="space-y-1">
-                <div className="font-medium">Execution Error</div>
-                <pre className="whitespace-pre-wrap text-red-400/80">{error}</pre>
+          >
+            {isRunning ? (
+              <RunningCodeSkeleton />
+            ) : error ? (
+              <div className="flex items-start gap-3 text-red-400">
+                <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-1" />
+                <div className="space-y-1">
+                  <div className="font-medium">Execution Error</div>
+                  <pre className="whitespace-pre-wrap text-red-400/80">{error}</pre>
+                </div>
               </div>
-            </div>
-          ) : output ? (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-emerald-400 mb-3">
-                <CheckCircle className="w-5 h-5" />
-                <span className="font-medium">Execution Successful</span>
+            ) : output ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-emerald-400 mb-3">
+                  <CheckCircle className="w-5 h-5" />
+                  <span className="font-medium">Execution Successful</span>
+                </div>
+                <pre className="whitespace-pre-wrap text-gray-300">{output}</pre>
               </div>
-              <pre className="whitespace-pre-wrap text-gray-300">{output}</pre>
-            </div>
-          ) : (
-            <div className="h-full flex flex-col items-center justify-center text-gray-500">
-              <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gray-800/50 ring-1 ring-gray-700/50 mb-4">
-                <Clock className="w-6 h-6" />
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center text-gray-500">
+                <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gray-800/50 ring-1 ring-gray-700/50 mb-4">
+                  <Clock className="w-6 h-6" />
+                </div>
+                <p className="text-center">Run your code to see the output here...</p>
               </div>
-              <p className="text-center">Run your code to see the output here...</p>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/(root)/_components/TerminalPanel.tsx
+++ b/src/app/(root)/_components/TerminalPanel.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import { Terminal } from "xterm";
+import "xterm/css/xterm.css";
+
+export default function TerminalPanel() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    if (containerRef.current && !termRef.current) {
+      const term = new Terminal({ convertEol: true, cursorBlink: true });
+      term.open(containerRef.current);
+      term.writeln("Interactive shell. Type commands below.");
+      termRef.current = term;
+    }
+    return () => {
+      termRef.current?.dispose();
+    };
+  }, []);
+
+  const sendCommand = async () => {
+    if (!input.trim() || !termRef.current) return;
+    termRef.current.writeln("$ " + input);
+    try {
+      const res = await fetch("/api/terminal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: input })
+      });
+      const data = await res.json();
+      if (data.output) termRef.current.writeln(data.output);
+      if (data.error) termRef.current.writeln(data.error);
+    } catch (e) {
+      const err = e as Error;
+      termRef.current.writeln("Error: " + err.message);
+    }
+    setInput("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      sendCommand();
+    }
+  };
+
+  return (
+    <div className="h-[600px] flex flex-col">
+      <div ref={containerRef} className="flex-1 overflow-hidden bg-[#1e1e2e] rounded-t-lg" />
+      <input
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="bg-[#1e1e2e] text-gray-300 text-sm p-2 rounded-b-lg outline-none border-t border-gray-700"
+        placeholder="Type a command and press Enter"
+      />
+    </div>
+  );
+}

--- a/src/app/api/terminal/route.ts
+++ b/src/app/api/terminal/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { exec } from "child_process";
+import util from "util";
+
+const execAsync = util.promisify(exec);
+
+export async function POST(req: NextRequest) {
+  const { command } = await req.json();
+  if (!command) {
+    return NextResponse.json({ output: "", error: "No command provided" }, { status: 400 });
+  }
+  try {
+    const { stdout, stderr } = await execAsync(command, { timeout: 10000 });
+    return NextResponse.json({ output: stdout, error: stderr });
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    return NextResponse.json({ output: e?.stdout || "", error: e?.stderr || e?.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add xterm.js dependency
- create TerminalPanel component
- update OutputPanel with Output/Terminal tabs
- add API route to execute shell commands

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68577e85aa108323b49a3745c76479af